### PR TITLE
Solucionar el error que bloqueaba el repl

### DIFF
--- a/lpp/repl.py
+++ b/lpp/repl.py
@@ -31,6 +31,7 @@ def start_repl() -> None:
 
         if len(parser.errors) > 0:
             _print_parse_errors(parser.errors)
+            scanned.pop()
             continue
 
         evaluated = evaluate(program, env)


### PR DESCRIPTION
Cuando escribimos en nuestro repl y este se encuenta con un error se "bloquea" la ejecución de las siguiente instrucciones que digitemos, ya que el error cometido queda registrado en 'scanned'.

La solición que se propone es que cuando el parser contenga errores, y luego de imprimir los errores, se eliminé el código que produjo el error de la variable 'scanned'.